### PR TITLE
com.webos.serivce.ime.role.json.in: Add org.maliit

### DIFF
--- a/service/com.webos.service.ime.role.json.in
+++ b/service/com.webos.service.ime.role.json.in
@@ -1,13 +1,19 @@
 {
     \"exeName\":\"$$WEBOS_INSTALL_BINS/MaliitServer\",
     \"type\":\"privileged\",
-    \"allowedNames\":[\"com.webos.service.ime*\"],
+    \"allowedNames\":[\"com.webos.service.ime*\","org.maliit\"],
     \"permissions\":[
         {
             \"service\":\"com.webos.service.ime*\",
             \"outbound\":[\"com.webos.notification\",\"com.webos.service.tts\",\"com.webos.settingsservice\",\"com.webos.service.config\",
             \"com.webos.service.nlp\",\"com.webos.audio\",\"com.webos.applicationManager\",\"com.webos.service.bluetooth\",
-            \"com.webos.service.mrcu\"]
+            \"com.webos.service.mrcu\", \"org.maliit\"]
+        },
+        {
+            \"service\":\"org.maliit\",
+            \"outbound\":[\"com.webos.notification\",\"com.webos.service.tts\",\"com.webos.settingsservice\",\"com.webos.service.config\",
+            \"com.webos.service.nlp\",\"com.webos.audio\",\"com.webos.applicationManager\",\"com.webos.service.bluetooth\",
+            \"com.webos.service.mrcu\", \"org.maliit\"]
         }
     ]
 }


### PR DESCRIPTION
Fixes: Apr 29 17:42:31 qemux86-64 ls-hubd[236]: [] [pmlog] ls-hubd LSHUB_NO_NAME_PERMS {"APP_ID":"org.maliit","ROLE_ID":"/usr/sbin/MaliitServer","EXE":"/usr/sbin/MaliitServer"} Executable: "/usr/sbin/MaliitServer" (cmdline: /usr/sbin/MaliitServer -instance 0) does not have permission to register name: "org.maliit"
Apr 29 17:42:31 qemux86-64 MaliitServer[803]: [] [pmlog] <default-lib> LS_REQ_NAME {"FILE":"transport.c","LINE":1931} Invalid permissions for org.maliit
Apr 29 17:42:31 qemux86-64 sh[803]: WARNING: Failed to register service handle: Invalid permissions for org.maliit
Apr 29 17:42:31 qemux86-64 ls-hubd[236]: [] [pmlog] ls-hubd LSHUB_UNK_DISC_MSG {"APP_ID":"(null)"} We received a disconnect message for client: 0x6bc180, but couldn't find it in the client map

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>